### PR TITLE
Sync yield_devices definitions

### DIFF
--- a/spreads/plugin.py
+++ b/spreads/plugin.py
@@ -163,9 +163,11 @@ class DevicePlugin(SpreadsPlugin):
             }
 
     @abstractclassmethod
-    def yield_devices(self):
+    def yield_devices(cls, config):
         """ Search for usable devices, yield one at a time
-
+        
+        :param config:  spreads configuration
+        :type config:   spreads.confit.ConfigView
         """
         raise NotImplementedError
 

--- a/spreadsplug/dev/chdkcamera.py
+++ b/spreadsplug/dev/chdkcamera.py
@@ -58,7 +58,9 @@ class CHDKCameraDevice(DevicePlugin):
     @classmethod
     def yield_devices(cls, config):
         """ Search for usable devices, yield one at a time
-
+        
+        :param config:  spreads configuration
+        :type config:   spreads.confit.ConfigView
         """
         for dev in usb.core.find(find_all=True):
             cfg = dev.get_active_configuration()[(0, 0)]


### PR DESCRIPTION
should it be 'self' or 'cls' in spreads.plugin ? spreadsplug.dev.chdkcamera uses 'cls'
