### PR TITLE
Disable flash after modifying capture mode (monochrome)

### DIFF
--- a/spreadsplug/dev/chdkcamera.py
+++ b/spreadsplug/dev/chdkcamera.py
@@ -159,8 +159,6 @@ class CHDKCameraDevice(DevicePlugin):
             self.logger.debug(e)
             self.logger.info("Camera already seems to be in recording mode")
         self._set_zoom(int(self.config['zoom_level'].get()))
-        # Disable flash
-        self._execute_lua("while(get_flash_mode()<2) do click(\"right\") end")
         # Disable ND filter
         self._execute_lua("set_nd_filter(2)")
         self._set_focus()
@@ -173,6 +171,9 @@ class CHDKCameraDevice(DevicePlugin):
             if not rv:
                 self.logger.warn("Monochrome mode not supported on this "
                                  "device, will be disabled.")
+        # Disable flash
+        self._execute_lua("while(get_flash_mode()<2) do click(\"right\") end")
+                                 
 
     def finish_capture(self):
         # Switch camera back to play mode.


### PR DESCRIPTION
After capture mode changes to monochrome, flash go to Auto mode.  So, the suggestion is to move flash setting instructions to the end of function.

To reproduce the bug (A1400 starts in P mode, Flash off)
1) Create a new workflow with default options, 
2) Capture, 
3) Change workflow settings to monochrome capture
4) Capture -> Flash trigger

Test with chdkptp:
connected: Canon PowerShot A1400, max packet size 512
con> rec
con 1> luar capmode=require('capmode'); return capmode.get_name()
2:return:'P'
con 2> =return get_flash_mode();
3:return:2
con 3> luar capmode=require('capmode'); return capmode.set('SCN_MONOCHROME');
4:return:true
con 4> =return get_flash_mode();
5:return:0
