### PR TITLE
Dummy device: model single device operation

### DIFF
--- a/spreadsplug/dev/dummy.py
+++ b/spreadsplug/dev/dummy.py
@@ -30,11 +30,18 @@ class DummyDevice(DeviceDriver):
                                        True, True)
         tmpl['depends'] = OptionTemplate(0, "A dependant option",
                                          depends={'device': {'super': 'bar'}})
+        tmpl['single'] = OptionTemplate(
+            value=False,
+            docstring="Simulate a single device instead of a pair")
         return tmpl
 
     @classmethod
     def yield_devices(cls, config):
-        return [cls(config, None, 'even'), cls(config, None, 'odd')]
+        if not config['single'].get(bool):
+            return [cls(config, None, 'even'), cls(config, None, 'odd')]
+        else:
+            # Single page emulation, only yield one device
+            return [cls(config, None, 'odd')]
 
     def __init__(self, config, device, target_page):
         base_path = Path(os.path.expanduser('~/.config/spreads'))


### PR DESCRIPTION
Add a configuration option 'single' to the template for the dummy device.
When this is set to 'yes', yield a single device rather than an odd/even
pair.

This is the beginnings of pulling through single-camera support in spreads - running with this configuration in place gives the error

```
There is a problem with your device configuration:
Please connect and turn on two pre-configured devices! (1 were found)
```

but it means I can work on sorting out the issues in the core code without having to have a camera connected.
