### PR TITLE
PEP8 fixes to partially resolve travis-ci build failure

### DIFF
--- a/spreads/cli.py
+++ b/spreads/cli.py
@@ -267,8 +267,9 @@ def capture(config):
     def _refresh_stats():
         """ Callback that prints up-to-date capture statistics to stdout """
         if _refresh_stats.start_time is not None:
-            pages_per_hour = ((3600/(time.time() - _refresh_stats.start_time))
-                              * len(workflow.pages))
+            pages_per_hour = ((3600/(time.time() -
+                                     _refresh_stats.start_time)) *
+                              len(workflow.pages))
         else:
             pages_per_hour = 0.0
             _refresh_stats.start_time = time.time()
@@ -285,9 +286,14 @@ def capture(config):
         if is_posix:
             import select
             old_settings = termios.tcgetattr(sys.stdin)
-            data_available = lambda: (select.select([sys.stdin], [], [], 0) ==
-                                      ([sys.stdin], [], []))
-            read_char = lambda: sys.stdin.read(1)
+
+            def data_available():
+                return (select.select([sys.stdin], [], [], 0) ==
+                        ([sys.stdin], [], []))
+
+            def read_char():
+                return sys.stdin.read(1)
+
         else:
             data_available = msvcrt.kbhit
             read_char = msvcrt.getch

--- a/spreads/config.py
+++ b/spreads/config.py
@@ -214,9 +214,9 @@ class Configuration(object):
         :type args:     :py:class:`argparse.Namespace`
         """
         for argkey, value in args.__dict__.iteritems():
-            skip = (value is None
-                    or argkey == 'subcommand'
-                    or argkey.startswith('_'))
+            skip = (value is None or
+                    argkey == 'subcommand' or
+                    argkey.startswith('_'))
             if skip:
                 continue
             if '.' in argkey:

--- a/spreads/main.py
+++ b/spreads/main.py
@@ -312,8 +312,11 @@ def main():
     """ Entry point for `spread` command-line application. """
     # Initialize color support
     colorama.init()
-    print_error = lambda x: print(util.colorize(x, colorama.Fore.RED),
-                                  file=sys.stderr)
+
+    def print_error(x):
+        print(util.colorize(x, colorama.Fore.RED),
+              file=sys.stderr)
+
     try:
         run()
     except util.DeviceException as e:

--- a/spreads/util.py
+++ b/spreads/util.py
@@ -292,8 +292,8 @@ class ColourStreamHandler(logging.StreamHandler):
             if not self.is_tty:
                 self.stream.write(message)
             else:
-                self.stream.write(self.colours[record.levelname]
-                                  + message + Style.RESET_ALL)
+                self.stream.write(self.colours[record.levelname] +
+                                  message + Style.RESET_ALL)
             self.stream.write(getattr(self, 'terminator', '\n'))
             self.flush()
         except (KeyboardInterrupt, SystemExit):

--- a/spreads/workflow.py
+++ b/spreads/workflow.py
@@ -344,8 +344,8 @@ class Workflow(object):
             found = []
         for candidate in location.iterdir():
             is_workflow = (location.is_dir() and
-                           ((candidate/'bagit.txt').exists
-                            or (candidate/'raw').exists))
+                           ((candidate/'bagit.txt').exists or
+                            (candidate/'raw').exists))
             if not is_workflow:
                 continue
             if not next((wf for wf in found if wf.path == candidate), None):
@@ -671,10 +671,10 @@ class Workflow(object):
             old_progress = self.status['step_progress']
             if old_progress is not None:
                 prog_diff = kwargs['step_progress'] - old_progress
-                trigger_event = (prog_diff >= 0.01     # Noticeable progress?
-                                 or prog_diff == -1    # New step?
-                                 or (old_progress < 1  # Completion?
-                                     and (old_progress + prog_diff) == 1))
+                trigger_event = (prog_diff >= 0.01 or   # Noticeable progress?
+                                 prog_diff == -1 or     # New step?
+                                 (old_progress < 1 and  # Completion?
+                                     (old_progress + prog_diff) == 1))
                 if not trigger_event:
                     kwargs.pop('step_progress', None)
         for key, value in kwargs.items():
@@ -842,10 +842,10 @@ class Workflow(object):
         if target_page is None:
             return base_path / "{03:0}".format(last_num+1)
 
-        is_raw = ('shoot_raw' in self.config['device'].keys()
-                  and self.config['device']['shoot_raw'].get(bool))
-        next_num = (last_num+1 if (self.is_single_camera
-                                   or target_page == 'even')
+        is_raw = ('shoot_raw' in self.config['device'].keys() and
+                  self.config['device']['shoot_raw'].get(bool))
+        next_num = (last_num+1 if (self.is_single_camera or
+                                   target_page == 'even')
                     else last_num+2)
         path = base_path / "{0:03}.{1}".format(next_num,
                                                'dng' if is_raw else 'jpg')
@@ -867,8 +867,8 @@ class Workflow(object):
                 futures.append(executor.submit(dev.prepare_capture))
         util.check_futures_exceptions(futures)
 
-        flip_target = ('flip_target_pages' in self.config['device'].keys()
-                       and self.config['device']['flip_target_pages'].get())
+        flip_target = ('flip_target_pages' in self.config['device'].keys() and
+                       self.config['device']['flip_target_pages'].get())
         if flip_target:
             (self.devices[0].target_page,
              self.devices[1].target_page) = (self.devices[1].target_page,
@@ -891,8 +891,8 @@ class Workflow(object):
             self._logger.info("Triggering capture.")
             on_capture_triggered.send(self)
             parallel_capture = (
-                'parallel_capture' in self.config['device'].keys()
-                and self.config['device']['parallel_capture'].get()
+                'parallel_capture' in self.config['device'].keys() and
+                self.config['device']['parallel_capture'].get()
             )
             num_devices = len(self.devices)
 

--- a/spreadsplug/gui/gui.py
+++ b/spreadsplug/gui/gui.py
@@ -358,8 +358,8 @@ class CapturePage(QtGui.QWizardPage):
         self.capture_btn.setFocus()
         self.shot_count += len(self.wizard().workflow.devices)
         if hasattr(self, '_start_time'):
-            capture_speed = ((3600 / (time.time() - self._start_time))
-                             * self.shot_count)
+            capture_speed = ((3600 / (time.time() - self._start_time)) *
+                             self.shot_count)
         else:
             self._start_time = time.time()
             capture_speed = 0.0

--- a/spreadsplug/web/app.py
+++ b/spreadsplug/web/app.py
@@ -69,8 +69,8 @@ try:
         """
         try:
             iface = next(dev for dev in netifaces.interfaces()
-                         if 'wlan' in dev or 'eth' in dev
-                         or dev.startswith('br'))
+                         if 'wlan' in dev or 'eth' in dev or
+                         dev.startswith('br'))
         except StopIteration:
             return None
         addresses = netifaces.ifaddresses(iface)
@@ -343,8 +343,9 @@ class WebApplication(object):
         try:
             device_driver = plugin.get_driver(self.global_config['driver']
                                               .get())
-            should_display_ip = (app.config['standalone'] and self._ip_address
-                                 and plugin.DeviceFeatures.CAN_DISPLAY_TEXT in
+            should_display_ip = (app.config['standalone'] and
+                                 self._ip_address and
+                                 plugin.DeviceFeatures.CAN_DISPLAY_TEXT in
                                  device_driver.features)
         except ConfigError:
             if self.config['mode'] not in ('scanner', 'full'):

--- a/spreadsplug/web/endpoints.py
+++ b/spreadsplug/web/endpoints.py
@@ -275,13 +275,13 @@ def _get_templates():
     elif app.config['mode'] == 'processor':
         templates = {section: config.templates[section]
                      for section in config.templates
-                     if section in plugins['postprocessing']
-                     or section in ('core', 'web')}
+                     if section in plugins['postprocessing'] or
+                     section in ('core', 'web')}
     elif app.config['mode'] == 'full':
         templates = {section: config.templates[section]
                      for section in config.templates
-                     if section in itertools.chain(*plugins.values())
-                     or section in ('core', 'device', 'web')}
+                     if section in itertools.chain(*plugins.values()) or
+                     section in ('core', 'device', 'web')}
     rv = dict()
     for plugname, options in templates.iteritems():
         if options is None:
@@ -340,13 +340,13 @@ def get_available_plugins():
     exts = list(pkg_resources.iter_entry_points('spreadsplug.hooks'))
     activated = app.config['default_config']['plugins'].get()
     post_plugins = sorted(
-        [ext.name for ext in exts if ext.name in activated
-         and issubclass(ext.load(), plugin.ProcessHooksMixin)],
+        [ext.name for ext in exts if ext.name in activated and
+         issubclass(ext.load(), plugin.ProcessHooksMixin)],
         key=lambda x: activated.index(x))
     return jsonify({
         'postprocessing': post_plugins,
-        'output': [ext.name for ext in exts if ext.name in activated
-                   and issubclass(ext.load(), plugin.OutputHooksMixin)]
+        'output': [ext.name for ext in exts if ext.name in activated and
+                   issubclass(ext.load(), plugin.OutputHooksMixin)]
     })
 
 

--- a/spreadsplug/web/handlers.py
+++ b/spreadsplug/web/handlers.py
@@ -318,8 +318,8 @@ class TarDownloadHandler(RequestHandler):
         self.fp.close()
 
     def on_exception(self, exc):
-        skip = (isinstance(exc[0], ValueError)
-                and "closed file" in exc[0].message)
+        skip = (isinstance(exc[0], ValueError) and
+                "closed file" in exc[0].message)
         if not skip:
             raise exc
 

--- a/spreadsplug/web/util.py
+++ b/spreadsplug/web/util.py
@@ -94,8 +94,8 @@ class CustomJSONEncoder(JSONEncoder):
                            'mimetype': path}
                           for path in workflow.out_files],
             'config': {k: v for k, v in workflow.config.flatten().iteritems()
-                       if k in workflow.config['plugins'].get()
-                       or k in ('device', 'plugins')}
+                       if k in workflow.config['plugins'].get() or
+                       k in ('device', 'plugins')}
         }
 
     def _logrecord_to_dict(self, record):
@@ -224,8 +224,8 @@ def find_stick():
     idevices = [dbus.Interface(dev, "org.freedesktop.DBus.Properties")
                 for dev in devices]
     try:
-        istick = next(i for i in idevices if i.Get("", "DeviceIsPartition")
-                      and i.Get("", "DriveConnectionInterface") == "usb")
+        istick = next(i for i in idevices if i.Get("", "DeviceIsPartition") and
+                      i.Get("", "DriveConnectionInterface") == "usb")
     except StopIteration:
         return
     return dbus.Interface(

--- a/tests/web_test.py
+++ b/tests/web_test.py
@@ -280,5 +280,5 @@ def test_get_logs(client):
                                     query_string={'start': 2, 'count': 5,
                                                   'level': 'debug'}).data)
     assert len(records['messages']) == 5
-    assert (records['messages'][0]['message']
-            == u'Sending finish_capture command to devices')
+    assert (records['messages'][0]['message'] ==
+            u'Sending finish_capture command to devices')


### PR DESCRIPTION
Hi @jbaiter,

It looks like pep8.py has been updated recently and travis-ci is failing.

This commit resolves warnings and errors from the latest version of pep8.py like:

```
W503 line break before binary operator
E731 do not assign a lambda expression, use a def
```

However, there are still these failures:

```
(spreadsenv)gareth@cagliostro:~/projects/bookscanner/spreads$ flake8 spreads spreadsplug tests --exclude=vendor
spreadsplug/web/app.py:50:1: E402 module level import not at top of file
spreadsplug/web/app.py:51:1: E402 module level import not at top of file
spreadsplug/web/app.py:52:1: E402 module level import not at top of file
spreadsplug/web/app.py:54:1: E402 module level import not at top of file
```

that has a big note in the comment beside them that I will be honest I don't understand. I hope at least that this patch is a start, though.