### PR TITLE
Fix support for Monochrome mode for CHDK buildnum > 3872

### DIFF
--- a/spreadsplug/dev/chdkcamera.py
+++ b/spreadsplug/dev/chdkcamera.py
@@ -191,7 +191,7 @@ class CHDKCameraDevice(DeviceDriver):
 
     def _set_monochrome(self):
         if self.config['monochrome'].get(bool):
-            if(self._chdk_buildnum >= 3872):
+            if self._chdk_buildnum >= 3872:
                 rv = self._device.lua_execute(
                     "capmode = require(\"capmode\")\n"
                     "return capmode.set(\"MONOCHROME\")")

--- a/spreadsplug/dev/chdkcamera.py
+++ b/spreadsplug/dev/chdkcamera.py
@@ -191,9 +191,14 @@ class CHDKCameraDevice(DeviceDriver):
 
     def _set_monochrome(self):
         if self.config['monochrome'].get(bool):
-            rv = self._device.lua_execute(
-                "capmode = require(\"capmode\")\n"
-                "return capmode.set(\"SCN_MONOCHROME\")")
+            if(self._chdk_buildnum >= 3872):
+		rv = self._device.lua_execute(
+			"capmode = require(\"capmode\")\n"
+			"return capmode.set(\"MONOCHROME\")")
+            else:
+		rv = self._device.lua_execute(
+			"capmode = require(\"capmode\")\n"
+			"return capmode.set(\"SCN_MONOCHROME\")")
             if not rv:
                 self.logger.warn("Monochrome mode not supported on this "
                                  "device, will be disabled.")

--- a/spreadsplug/dev/chdkcamera.py
+++ b/spreadsplug/dev/chdkcamera.py
@@ -192,13 +192,13 @@ class CHDKCameraDevice(DeviceDriver):
     def _set_monochrome(self):
         if self.config['monochrome'].get(bool):
             if(self._chdk_buildnum >= 3872):
-		rv = self._device.lua_execute(
-			"capmode = require(\"capmode\")\n"
-			"return capmode.set(\"MONOCHROME\")")
+                rv = self._device.lua_execute(
+                    "capmode = require(\"capmode\")\n"
+                    "return capmode.set(\"MONOCHROME\")")
             else:
-		rv = self._device.lua_execute(
-			"capmode = require(\"capmode\")\n"
-			"return capmode.set(\"SCN_MONOCHROME\")")
+                rv = self._device.lua_execute(
+                    "capmode = require(\"capmode\")\n"
+                    "return capmode.set(\"SCN_MONOCHROME\")")
             if not rv:
                 self.logger.warn("Monochrome mode not supported on this "
                                  "device, will be disabled.")


### PR DESCRIPTION
CHDK modelist names were modified on revision [3872](https://www.assembla.com/code/chdk/subversion/commit/3872). 