### PR TITLE
Unpin sphinxcontrib-fulltoc

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ pytest-qt >= 1.0
 pytest-cov >= 1.6
 pytest >= 2.5.1
 coveralls >= 0.2
-sphinxcontrib-fulltoc==1.0
+sphinxcontrib-fulltoc>=1.0
 mock>=1.0.1
 coverage>=3.6
 psutil==2.0.0


### PR DESCRIPTION
sphinxcontrib-fulltoc version 1.0 is not compatible with Python 3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/diybookscanner/spreads/224)
<!-- Reviewable:end -->
