### PR TITLE
Replace ppa:pyside/ppa with python-qt4 dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ python:
   - "2.7"
 before_install:
     - pip install -U setuptools
-    - sudo add-apt-repository -y ppa:pyside/ppa
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libusb-dev python-pyside libffi-dev libjpeg8-dev libudev-dev libusb-1.0-0-dev python-dbus liblua5.2-dev libusb-dev
-    - ln -s /usr/lib/python2.7/dist-packages/PySide /usr/lib/python2.7/dist-packages/*dbus* ~/virtualenv/python2.7/lib/python2.7/site-packages/
+    - sudo apt-get install -qq libusb-dev libffi-dev libjpeg8-dev libudev-dev libusb-1.0-0-dev python-dbus liblua5.2-dev python-qt4
+    - ln -s /usr/lib/python2.7/dist-packages/PyQt4 /usr/lib/python2.7/dist-packages/*dbus* ~/virtualenv/python2.7/lib/python2.7/site-packages/
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
     - sleep 3


### PR DESCRIPTION
Removes the need to perform "apt-get update", and
reduces the time taken by "apt-get install ...".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/diybookscanner/spreads/226)
<!-- Reviewable:end -->
