### PR TITLE
Remove unnecessary Travis dependency on pytest-qt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,14 @@ python:
   - "2.7"
 before_install:
     - pip install -U setuptools
-    - sudo add-apt-repository -y ppa:pyside/ppa
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libusb-dev python-pyside libffi-dev libjpeg8-dev libudev-dev libusb-1.0-0-dev python-dbus liblua5.2-dev libusb-dev
-    - ln -s /usr/lib/python2.7/dist-packages/PySide /usr/lib/python2.7/dist-packages/*dbus* ~/virtualenv/python2.7/lib/python2.7/site-packages/
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
-    - sleep 3
+    - sudo apt-get install -qq libusb-dev libffi-dev libjpeg8-dev libudev-dev libusb-1.0-0-dev python-dbus liblua5.2-dev
+    - ln -s /usr/lib/python2.7/dist-packages/*dbus* ~/virtualenv/python2.7/lib/python2.7/site-packages/
 install:
     - pip install lupa --install-option='--no-luajit'
     - pip install cffi flake8 pyflakes pep8-naming
     - pip install -e ".[web,hidtrigger,autorotate,chdkcamera]"
-    - pip install -r test-requirements.txt
+    # remove pytest-qt and whitespace from the test requirements
+    - pip install $(sed -e '/pytest-qt/d;s/ //g' test-requirements.txt)
     - pip install -e .
 script:
     - flake8 spreads spreadsplug tests --exclude=vendor

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+# pytest-qt is only needed for the gui tests
 pytest-qt >= 1.0
 pytest-cov >= 1.6
 pytest >= 2.5.1


### PR DESCRIPTION
The gui tests that depend on pytest-qt are disabled using
the pytest marker 'guitest'.

